### PR TITLE
WF Update t3.small instances

### DIFF
--- a/portal_objects/metaworkflows/Hi-C_alignment_GRCh38.yaml
+++ b/portal_objects/metaworkflows/Hi-C_alignment_GRCh38.yaml
@@ -308,7 +308,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: "1.1x"
       ebs_optimized: True
       spot_instance: True
@@ -732,7 +734,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/Hi-C_alignment_GRCh38.yaml
+++ b/portal_objects/metaworkflows/Hi-C_alignment_GRCh38.yaml
@@ -739,6 +739,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_BAM_Quality_Metrics_single-end
       behavior_on_capacity_limit: wait_and_retry

--- a/portal_objects/metaworkflows/Illumina_alignment_GRCh38.yaml
+++ b/portal_objects/metaworkflows/Illumina_alignment_GRCh38.yaml
@@ -894,7 +894,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: "1.1x"
       ebs_optimized: True
       spot_instance: True
@@ -1501,7 +1503,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/Illumina_alignment_GRCh38.yaml
+++ b/portal_objects/metaworkflows/Illumina_alignment_GRCh38.yaml
@@ -1508,6 +1508,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_BAM_Quality_Metrics_paired-end
       behavior_on_capacity_limit: wait_and_retry

--- a/portal_objects/metaworkflows/ONT_alignment_GRCh38.yaml
+++ b/portal_objects/metaworkflows/ONT_alignment_GRCh38.yaml
@@ -1024,6 +1024,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_BAM_Quality_Metrics_single-end_verifybamid2
       behavior_on_capacity_limit: wait_and_retry

--- a/portal_objects/metaworkflows/ONT_alignment_GRCh38.yaml
+++ b/portal_objects/metaworkflows/ONT_alignment_GRCh38.yaml
@@ -481,7 +481,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: "1.1x"
       ebs_optimized: True
       spot_instance: True
@@ -1017,7 +1019,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/PacBio_alignment_GRCh38.yaml
+++ b/portal_objects/metaworkflows/PacBio_alignment_GRCh38.yaml
@@ -424,7 +424,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: "1.1x"
       ebs_optimized: True
       spot_instance: True
@@ -966,7 +968,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/PacBio_alignment_GRCh38.yaml
+++ b/portal_objects/metaworkflows/PacBio_alignment_GRCh38.yaml
@@ -973,6 +973,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_BAM_Quality_Metrics_single-end_verifybamid2
       behavior_on_capacity_limit: wait_and_retry

--- a/portal_objects/metaworkflows/RNA-seq_bulk_short_reads_GRCh38.yaml
+++ b/portal_objects/metaworkflows/RNA-seq_bulk_short_reads_GRCh38.yaml
@@ -571,7 +571,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/RNA-seq_bulk_short_reads_GRCh38.yaml
+++ b/portal_objects/metaworkflows/RNA-seq_bulk_short_reads_GRCh38.yaml
@@ -576,6 +576,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_RNA-SeQC_Quality_Metrics
       behavior_on_capacity_limit: wait_and_retry

--- a/portal_objects/metaworkflows/RNA-seq_kinnex_long_reads_GRCh38.yaml
+++ b/portal_objects/metaworkflows/RNA-seq_kinnex_long_reads_GRCh38.yaml
@@ -1002,7 +1002,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/RNA-seq_kinnex_long_reads_GRCh38.yaml
+++ b/portal_objects/metaworkflows/RNA-seq_kinnex_long_reads_GRCh38.yaml
@@ -1007,6 +1007,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_Kinnex_Quality_Metrics
       behavior_on_capacity_limit: wait_and_retry


### PR DESCRIPTION
* Replace the `t3.small` instance with `c7a.medium`, `c8a.medium`, and `m7a.medium` because `t3.small` is no longer reliable